### PR TITLE
Remove phpdbg from coverage targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ tests:
 	vendor/bin/tester -s -p php --colors 1 -C tests/cases
 
 coverage-clover:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases
 
 coverage-html:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/cases


### PR DESCRIPTION
## Summary

Replace `phpdbg` with `php` in both coverage Makefile targets so this repository follows the org-wide coverage command migration from contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. Using `php` keeps the command consistent with the intended setup and avoids relying on PHPDBG SAPI.

## Changes

- switch `coverage-clover` from `-p phpdbg` to `-p php`
- switch `coverage-html` from `-p phpdbg` to `-p php`

## Testing

- [x] `make tests`
- [ ] `make coverage-clover` (blocked locally: no Xdebug or PCOV extension installed for `php`)
- [ ] CI passes