### PR TITLE
Use php in coverage targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ tests:
 	vendor/bin/tester -s -p php --colors 1 -C tests/cases
 
 coverage-clover:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases
 
 coverage-html:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/cases


### PR DESCRIPTION
## What changed
- switched the Makefile coverage targets from `-p phpdbg` to `-p php`

## Why
- aligns this repository with the org-wide phpdbg removal tracked in contributte/contributte#73